### PR TITLE
Add noresvport option to EFS mount

### DIFF
--- a/training-on-emr/emr_efs_bootstrap.sh
+++ b/training-on-emr/emr_efs_bootstrap.sh
@@ -19,10 +19,10 @@ if [[ -z "$1" || -z "$2" ]]
     echo "Missing mandatory arguments: File system ID, region"
     exit 1
 fi
- 
+
 # get file system id from input argument
 fs_id=$1
- 
+
 # get region from input argument
 region_id=$2
 
@@ -35,7 +35,7 @@ do
   times=$(( $times + 1 ))
   echo Attempt $times at verifying efs $fs_id is available...
 done
- 
+
 # verify mount target is ready
 times=0
 echo
@@ -45,21 +45,21 @@ do
   times=$(( $times + 1 ))
   echo Attempt $times at verifying efs $fs_id mount target is available...
 done
- 
+
 # create local path to mount efs
 sudo mkdir -p /efs
- 
+
 # mount efs
 sudo mount -t nfs4 \
-           -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 \
+           -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport \
            $fs_id.efs.$region_id.amazonaws.com:/ \
            /efs
- 
+
 cd /efs
- 
+
 # give hadoop user permission to efs directory
 sudo chown -R hadoop:hadoop .
- 
+
 if grep  $fs_id /proc/mounts; then
   echo "File system is mounted successfully."
 else


### PR DESCRIPTION
AWS Support recently identified a number of EFS filesystems mounted without the `noresvport` option. Upon investigation, we found this is due to us using the `emr_efs_bootstrap.sh` from here. This PR updates this script to add `noresvport` as suggested by AWS Support.
